### PR TITLE
handle unicode error when loading log.las

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ reference/
 __pycache__/
 .vscode/launch.json
 .vscode/settings.json
+proj/

--- a/app.py
+++ b/app.py
@@ -11,24 +11,29 @@ import raw_data
 import plotting
 import header
 
+from io import StringIO
+
 local_css("style.css")
 
+
 @st.cache
-def load_data(uploadedfile):
-    if uploadedfile:
-        string = uploadedfile.read().decode()
-        las_file = lasio.read(string)
+def load_data(uploaded_file):
+    if uploaded_file is not None:
+        try:
+            bytes_data = uploaded_file.read()
+            str_io = StringIO(bytes_data.decode('Windows-1252'))
+            las_file = lasio.read(str_io)
+            well_data = las_file.df()
+            well_data['DEPTH'] = well_data.index
 
-        # Create the dataframe
-        well_data = las_file.df()
-
-        #Assign the dataframe index to a curve
-        well_data['DEPTH'] = well_data.index
+        except UnicodeDecodeError as e:
+            print(f"error loading log.las: {e}")
     else:
-        las_file=None
-        well_data=None
-    
+        las_file = None
+        well_data = None
+
     return las_file, well_data
+
 
 #TODO
 def missing_data():
@@ -42,7 +47,7 @@ las_file=None
 st.sidebar.write('# LAS Data Explorer')
 st.sidebar.write('To begin using the app, load your LAS file using the file upload option below.')
 
-uploadedfile = st.sidebar.file_uploader(' ', type=['las'])
+uploadedfile = st.sidebar.file_uploader(' ', type=['.las'])
 las_file, well_data = load_data(uploadedfile)
 
 if las_file:

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ def load_data(uploaded_file):
             well_data['DEPTH'] = well_data.index
 
         except UnicodeDecodeError as e:
-            print(f"error loading log.las: {e}")
+            st.error(f"error loading log.las: {e}")
     else:
         las_file = None
         well_data = None


### PR DESCRIPTION
Modified `load_data` func to handle las files with strange encoding: 

1. Read log to bytes with built in read()
2. Build a StringIO object from bytes
3. Decoded object to string with forced windows-1252 encoding (this is the fix)
4. Read to las object and dataframe via lasio

Explicitly handled `UnicodeDecodeError` in try block. 

Test logs loaded and displayed correctly after change (screenshot). Note: these logs are also missing header section ~P, but I think lasio handles that internally. 

![image](https://user-images.githubusercontent.com/43920353/104452271-62f33d80-5568-11eb-9a31-3d3555391767.png)
 